### PR TITLE
fix: use perf counter for benchmark timing

### DIFF
--- a/flexgen/timer.py
+++ b/flexgen/timer.py
@@ -23,7 +23,7 @@ class _Timer:
         if sync_func:
             sync_func()
 
-        self.start_time = time.time()
+        self.start_time = time.perf_counter()
         self.start_times.append(self.start_time)
         self.started = True
 
@@ -33,7 +33,7 @@ class _Timer:
         if sync_func:
             sync_func()
 
-        stop_time = time.time()
+        stop_time = time.perf_counter()
         self.costs.append(stop_time - self.start_time)
         self.stop_times.append(stop_time)
         self.started = False
@@ -88,7 +88,7 @@ class Tracer:
         if sync_func:
             sync_func()
 
-        self.events.append(Event(time.time(), name, info))
+        self.events.append(Event(time.perf_counter(), name, info))
 
 
 tracer = Tracer()


### PR DESCRIPTION
Need to choose a monotonic clock for benchmark timing.

`time.perf_counter` should be much more accurate. I guess it's not necessary to use a `perf_counter_ns`.

Ref: https://docs.python.org/3/library/time.html#time.perf_counter