### PR TITLE
Resolve typos in comments and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ FlexGen can be flexibly configured under various hardware resource constraints b
 
 One key idea of FlexGen is to play the latency-throughput trade-off. Achieving low latency is inherently challenging for offloading methods, 
 but the efficiency of offloading can be greatly boosted for throughput-oriented scenarios (see the figure above).
-FlexGen utilizes a block schedule to reuse weight and overlap I/O with computation, as shown in figure (b) below, while other baseline systems use an ineffiicent row-by-row schedule, as shown in figure (a) below.
+FlexGen utilizes a block schedule to reuse weight and overlap I/O with computation, as shown in figure (b) below, while other baseline systems use an inefficient row-by-row schedule, as shown in figure (a) below.
 
 <img src="https://github.com/FMInference/FlexGen/raw/main/docs/block_schedule.jpg" alt="logo" width="500"></img>
 
@@ -115,7 +115,7 @@ python3 -m flexgen.flex_opt --model facebook/opt-30b --percent 0 100 100 0 100 0
 
 ### OPT-175B
 To run OPT-175B, you need to download the weights from [metaseq](https://github.com/facebookresearch/metaseq/tree/main/projects/OPT) and convert the weights into Alpa [format](https://alpa.ai/tutorials/opt_serving.html#convert-opt-175b-weights-into-alpa-formats).
-You can then try to offloaind all wieghts to disk by
+You can then try to offloading all weights to disk by
 ```
 python3 -m flexgen.flex_opt --model facebook/opt-175b --percent 0 0 100 0 100 0 --offload-dir YOUR_SSD_FOLDER
 ```
@@ -123,7 +123,7 @@ python3 -m flexgen.flex_opt --model facebook/opt-175b --percent 0 0 100 0 100 0 
 ### How to set the offloading strategy and `--percent`?
 We will release an automatic policy optimizer later, but now you have to manually try a few strategies.
 The idea of high-throughput generation is to offload parameters and attention cache as much as possible to the CPU and disk if necessary.
-You can see the reference startegies in our benchmark [here](https://github.com/FMInference/FlexGen/blob/9d092d848f106cd9eaf305c12ef3590f7bcb0277/benchmark/flexgen/bench_suite.py#L39-L79).
+You can see the reference strategies in our benchmark [here](https://github.com/FMInference/FlexGen/blob/9d092d848f106cd9eaf305c12ef3590f7bcb0277/benchmark/flexgen/bench_suite.py#L39-L79).
 To avoid out-of-memory, you can tune the `--percent` of offload more tensors to the CPU and disk.
 
 ## Scaling to Distributed GPUs
@@ -179,7 +179,7 @@ They save more memory but run slower.
 We plan to work on the following features. Community contributions are welcome.
 
 - [ ] Support Apple silicon M1/M2 deployment
-- [ ] Support Colab deployement
+- [ ] Support Colab deployment
 - [ ] Add a text summarization application and more throughput-oriented applications.
 - [ ] Optimize the latency of the chatbot application
 - [ ] Support more models (BLOOM, CodeGen, GLM)

--- a/flexgen/dist_flex_opt.py
+++ b/flexgen/dist_flex_opt.py
@@ -171,7 +171,7 @@ class DistOptLM(OptLM):
             self.hidden[t][i][j][k].store(val)
             return
         if self.num_pipeline_stages > 1 and not (i == 0 and self.pipeline_rank == 0):
-            # Alreday received the input from previous hidden states
+            # Already received the input from previous hidden states
             self.hidden[t][i][j][k].val = self.hidden[t][i][j][k].val.move(dst)
             return
         gpu_batch_size = self.policy.gpu_batch_size

--- a/flexgen/dist_utils.py
+++ b/flexgen/dist_utils.py
@@ -38,7 +38,7 @@ def initialize_distributed(head_ip, port, world_size, rank, local_rank,
                 _PIPELINE_PARALLEL_SUCC_GROUP = group
 
     suppress_output(rank)
-    print("Finshed initializing distributed environment")
+    print("Finished initializing distributed environment")
 
 def get_pipeline_parallel_pred_group():
     return _PIPELINE_PARALLEL_PRED_GROUP

--- a/flexgen/flex_opt.py
+++ b/flexgen/flex_opt.py
@@ -978,7 +978,7 @@ class OptLM:
             else:
                 timers("generate").costs.append(self.num_layers * batch_cost)
 
-        # Debug the costs of individual funcions
+        # Debug the costs of individual functions
         print(f"#layers: {self.num_layers}")
 
         print(f"#batches prefill:  "

--- a/flexgen/pytorch_backend.py
+++ b/flexgen/pytorch_backend.py
@@ -204,7 +204,7 @@ class TorchDevice:
             self.attention_compute_workspace = []
             self.workspace_pt = 0
 
-            # We currenly separate SelfAttention and MLP as two layers,
+            # We currently separate SelfAttention and MLP as two layers,
             # so we only need one workspace instead of two.
             for i in range(1 if policy.sep_layer else 2):
                 shape = (max_seq_len, b * n_head, head_dim)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Resolve a handful of typos in comments throughout this repository, as well as the README.

## Details
The typos were automatically detected using [`codespell`](https://github.com/codespell-project/codespell) and manually fixed if they indeed were a typo. For the README I also did some further manual checking.

As a sidenote: you've managed some very impressive results here! Well done.

- Tom Aarsen