### PR TITLE
fix import error

### DIFF
--- a/flexgen/utils.py
+++ b/flexgen/utils.py
@@ -1,7 +1,7 @@
 import argparse
 import dataclasses
-from attrs import define, field
-from attrs.setters import frozen
+from attr import define, field
+from attr.setters import frozen
 import functools
 import gc
 import math


### PR DESCRIPTION
## Description

fix import library name.
```
attrs --> attr
```

## What fixed
The following error occurs and needs to be corrected.

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/USERNAME/FlexGen/flexgen/flex_opt.py", line 18, in <module>
    from flexgen.compression import CompressionConfig
  File "/home/USERNAME/FlexGen/flexgen/compression.py", line 6, in <module>
    from flexgen.pytorch_backend import (TorchTensor, TorchDevice,
  File "/home/USERNAME/FlexGen/flexgen/pytorch_backend.py", line 15, in <module>
    from flexgen.utils import (GB, T, cpu_mem_stats, vector_gather,
  File "/home/USERNAME/FlexGen/flexgen/utils.py", line 3, in <module>
    from attrs import define, field
ModuleNotFoundError: No module named 'attrs'

```

## Check env
- Ubuntu 22.04 LTS
- CUDA 11.6
