### PR TITLE
Allow FlexGen to use locally downloaded models

### DIFF
--- a/flexgen/opt_config.py
+++ b/flexgen/opt_config.py
@@ -51,7 +51,7 @@ class OptConfig:
 
 def get_opt_config(name, **kwargs):
     if "/" in name:
-        name = name.split("/")[1]
+        name = name.split("/")[-1]
     name = name.lower()
 
     # Handle opt-iml-30b and opt-iml-max-30b


### PR DESCRIPTION
Check the last string after `/` instead of the first string. It can allow FlexGen to use local model path like `/home/usr/model/facebook/opt-1.3b`.