### PR TITLE
Add support for symmetric quantization

### DIFF
--- a/flexgen/flex_opt.py
+++ b/flexgen/flex_opt.py
@@ -1205,7 +1205,7 @@ def run_flexgen(args):
                                       group_dim=0, symmetric=False),
                     args.compress_cache,
                     CompressionConfig(num_bits=4, group_size=64,
-                                      group_dim=2, symmetric=False))
+                                      group_dim=2, symmetric=True))
     assert not (args.compress_cache and args.attn_sparsity < 1.0), "Not implemented"
 
     opt_config = get_opt_config(args.model)


### PR DESCRIPTION
This PR adds support for symmetric quantization when compressing/decompressing tensors. This is useful for comparing the performance of both symmetric and asymmetric quantization.
- supports storing compressed tensors without zero point
- adds some bitwise operations to support signed quantized values